### PR TITLE
Added merge command to pyson db cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,6 @@
 
 * `0.8.0`
   * Fixed `name` not defined error in `cli.py`
+
+* `0.9.0`
+  * Added merge command to the cli tool

--- a/pysondb/cli.py
+++ b/pysondb/cli.py
@@ -120,9 +120,7 @@ def merge(p_file: str, m_file: str, output_file: Optional[str] = None):
             quit()
         except IndexError:
             print("One of the Database is empty")
-
-    print(p_data)
-    print(m_data)
+            quit()
 
     # merge the two DB together
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="Apache Software License 2.0",
     long_description=readme,
     long_description_content_type="text/markdown",
-    version="0.8.0",
+    version="0.9.0",
     keywords="pysondb,database,json,yaml",
     name="pysondb",
     packages=["pysondb"],


### PR DESCRIPTION
A new command called merge has been added to the CLI tool, it merges two json DB that follows the pyson db schema i.e, 
```json
{"data": [{...}, {...}]}
```
together.
It also make sure that the keys are the same in all the entries in a database, and the keys in two different database files to be merged are the same. Else error will be shown.

Usage:
```commandline
pysondb merge primary.json second.json output.json
```
The output file is optional, if not passed, it merges it into the primary.json files