### PR TITLE
Objectify | convert json to python objects instanlty | log fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@
 
 * `0.9.0`
   * Added merge command to the cli tool
+
+* `1.0.3`
+  * Added a kwarg log to the JsonDatabase class to stop the log
+  * Adde a kwarg objectify to all the get and search methods to convert json to python objects

--- a/docs/get.md
+++ b/docs/get.md
@@ -13,9 +13,9 @@
 <h2>Get Data</h2>
 
 * There are three methods to get data.
-  * get(n)
-  * getAll()
-  * getBy()
+  * get(n, objectify=False)
+  * getAll(objectify=False)
+  * getBy(query, objectify=False)
 
 
 <h2><code>get()</code></h2>
@@ -62,9 +62,9 @@ path.json
 >> [{"name":"py_cli","type":"CLI"},{"name":"py_cli2","type":"CLI"}]
 >> a.getBy({"name":"py_cli"})
 >> [{"name":"py_cli","type":"CLI"}]
-
-
 ```
+
+* The objectify kwarg converts the json data to python object, thus the values can be easily accessed by dot(.) notation.
 
 * See full examples [here](https://github.com/fredysomy/pysonDB/example). 
 * If You have any queries or doubts join the discord server [here](https://discord.gg/SZyk2dCgwg)

--- a/docs/re_search.md
+++ b/docs/re_search.md
@@ -13,7 +13,7 @@
 <h2>Search using Regex</h2>
 
 * Methods
-  * reSearch(key,regex)
+  * reSearch(key, regex, objectify=False)
   * Searches for the objects where the value of the key follows the given regex. 
 
 ***
@@ -32,7 +32,7 @@
 
 ***  
 
-<h2><code>reSearch(key,regex)</code></h2>
+<h2><code>reSearch(key, regex, objectify=False)</code></h2>
 
 ```python
 >> from pysondb import db

--- a/pysondb/db.py
+++ b/pysondb/db.py
@@ -46,7 +46,7 @@ class JsonDatabase:
     def __init__(self, filename, id_fieldname="id", log=False):
         a = Database().on(filename)
         sdx = Path(filename)
-        
+
         self._id_fieldname = id_fieldname
         self.filename = filename
         self.lock = FileLock("{}.lock".format(self.filename))
@@ -67,6 +67,10 @@ class JsonDatabase:
 
     def _get_dump_function(self):
         return json.dump
+
+    @staticmethod
+    def _objectify(data):
+        return json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
 
     @staticmethod
     def _stop_log():
@@ -131,9 +135,6 @@ class JsonDatabase:
                             self._get_dump_function()(db_data, db_file)
 
     def getAll(self, objectify=False):
-        def _objectify(data):
-            return json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
-
         with self.lock:
             with open(self.filename, "r", encoding="utf8") as db_file:
                 db_data = self._get_load_function()(db_file)
@@ -141,16 +142,21 @@ class JsonDatabase:
             return (
                 db_data["data"]
                 if not objectify
-                else _objectify(json.dumps(db_data)).data
+                else self._objectify(json.dumps(db_data)).data
             )
 
-    def get(self, num=1):
+    def get(self, num=1, objectify=False):
         with self.lock:
             try:
                 with open(self.filename, "r", encoding="utf8") as db_file:
                     db_data = self._get_load_function()(db_file)
                 if num <= len(db_data["data"]):
-                    return db_data["data"][0 : int(num)]
+                    data = db_data["data"][0 : int(num)]
+                    return (
+                        data
+                        if not objectify
+                        else self._objectify(json.dumps({"data": data})).data
+                    )
                 else:
                     logger.info(
                         "The length you have given {} \n Length of the database items= {}".format(
@@ -161,7 +167,7 @@ class JsonDatabase:
             except:
                 return []
 
-    def getBy(self, query):
+    def getBy(self, query, objectify=False):
         with self.lock:
             result = []
             with open(self.filename, "r") as db_file:
@@ -169,9 +175,13 @@ class JsonDatabase:
                 for d in db_data["data"]:
                     if all(x in d and d[x] == query[x] for x in query):
                         result.append(d)
-            return result
+            return (
+                result
+                if not objectify
+                else self._objectify(json.dumps({"data": result})).data
+            )
 
-    def reSearch(self, key, _re):
+    def reSearch(self, key, _re, objectify=False):
         pattern = _re
         if not isinstance(_re, re.Pattern):
             pattern = re.compile(str(_re))
@@ -185,7 +195,11 @@ class JsonDatabase:
                     items.append(d)
                     continue
 
-        return items
+        return (
+            items
+            if not objectify
+            else self._objectify(json.dumps({"data": items})).data
+        )
 
     def updateById(self, pk, new_data):
         with self.lock:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="MIT License",
     long_description=readme,
     long_description_content_type="text/markdown",
-    version="1.0.2",
+    version="1.0.3",
     keywords="pysondb,database,json,yaml",
     name="pysondb",
     packages=["pysondb"],


### PR DESCRIPTION
>> The docs are also added

First things first

```commandline
INFO:pysondb:Database Filename: test.json
DEBUG:filelock:Attempting to acquire lock 1615691988128 on test.json.lock
INFO:filelock:Lock 1615691988128 acquired on test.json.lock
DEBUG:filelock:Attempting to release lock 1615691988128 on test.json.lock
INFO:filelock:Lock 1615691988128 released on test.json.lock
[namespace(name='pysondb', type='DB'), namespace(name='pysondb-cli', type='CLI'), namespace(name='fire', type='CLI'), namespace(name='stuff.py', type='GUI'), namespace(name='def23@c-py', type='TUI'), namespace(name='stuff(py', type='GUI')]
DEBUG:filelock:Attempting to acquire lock 1615691988128 on test.json.lock
INFO:filelock:Lock 1615691988128 acquired on test.json.lock
DEBUG:filelock:Attempting to release lock 1615691988128 on test.json.lock
INFO:filelock:Lock 1615691988128 released on test.json.lock
[namespace(name='pysondb', type='DB'), namespace(name='pysondb-cli', type='CLI'), namespace(name='fire', type='CLI')]
DEBUG:filelock:Attempting to acquire lock 1615691988128 on test.json.lock
INFO:filelock:Lock 1615691988128 acquired on test.json.lock
DEBUG:filelock:Attempting to release lock 1615691988128 on test.json.lock
INFO:filelock:Lock 1615691988128 released on test.json.lock
DB
DEBUG:filelock:Attempting to acquire lock 1615691988128 on test.json.lock
INFO:filelock:Lock 1615691988128 acquired on test.json.lock
DEBUG:filelock:Attempting to release lock 1615691988128 on test.json.lock
INFO:filelock:Lock 1615691988128 released on test.json.lock
[namespace(name='def23@c-py', type='TUI')]
```

This log feature sucks

so in order to prevent this a new keyword argument (kwarg) `log` is added the the JsonDatabase class that allows the user to see or hide the logs

## usage
```python
from pysondb import db
a = db.getDb("test.json", log=False)  # stops all the logs, default is False
```

#####################################################################

The `objectify`  kwarg
default: False

test.json
```json
{
    "data": [
        {
            "name": "pysondb",
            "type": "DB"
        },
        {
            "name": "pysondb-cli",
            "type": "CLI"
        },
        {
            "name": "fire",
            "type": "CLI"
        },
        {
            "name": "stuff.py",
            "type": "GUI"
        },
        {
            "name": "def23@c-py",
            "type": "TUI"
        },
        {
            "name": "stuff(py",
            "type": "GUI"
        }
    ]
}
```

```python
from pysondb import db

a = db.getDb("test.json", log=False)  # the logs are turned off

print(a.getAll(objectify=True))

print(a.get(3, objectify=True))
print(a.getBy({"name": "pysondb"}, objectify=True)[0].type)
print(a.reSearch("name", r"\w{3}\d{2}@c-py", objectify=True))
```

ouput

```commandline
[namespace(name='pysondb', type='DB'), namespace(name='pysondb-cli', type='CLI'), namespace(name='fire', type='CLI'), namespace(name='stuff.py', type='GUI'), namespace(name='def23@c-py', type='TUI'), namespace(name='stuff(py', type='GUI')]
[namespace(name='pysondb', type='DB'), namespace(name='pysondb-cli', type='CLI'), namespace(name='fire', type='CLI')]
DB
[namespace(name='def23@c-py', type='TUI')]
```

>> none of these changes will break the older version, as all the additional kwargs are optional