### PR TITLE
A method to remove all the records from the DB

### DIFF
--- a/pysondb/db.py
+++ b/pysondb/db.py
@@ -288,7 +288,7 @@ class JsonDatabase:
                 self._get_dump_function()(db_data, db_file)
             return True
 
-    def deletAll(self) -> None:
+    def deleteAll(self) -> None:
         with self.lock:
             with open(self.filename, "w") as f:
                 f.write(json.dumps(EMPTY_DATA))

--- a/pysondb/db.py
+++ b/pysondb/db.py
@@ -288,6 +288,11 @@ class JsonDatabase:
                 self._get_dump_function()(db_data, db_file)
             return True
 
+    def deletAll(self) -> None:
+        with self.lock:
+            with open(self.filename, "w") as f:
+                f.write(json.dumps(EMPTY_DATA))
+
     def update(self, db_dataset: Dict[str, Any], new_dataset: Dict[str, Any]) -> None:
         with self.lock:
             with open(self.filename, "r+") as db_file:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="MIT License",
     long_description=readme,
     long_description_content_type="text/markdown",
-    version="1.1.4",
+    version="1.1.5",
     keywords="pysondb,database,json,yaml",
     name="pysondb",
     packages=["pysondb"],


### PR DESCRIPTION
```json
/ / test.json
{
	"data": [
		{ "name": 0, "id": 249277026240141371 },
		{ "name": 1, "id": 249252087344273924 },
		{ "name": 2, "id": 454686401064316099 },
		{ "name": 3, "id": 892189500067897341 },
		{ "name": 4, "id": 301429584510657502 },
		{ "name": 5, "id": 340111333160185688 },
		{ "name": 6, "id": 273854578052259894 },
		{ "name": 7, "id": 178751929807873843 },
		{ "name": 8, "id": 120658743853783199 },
		{ "name": 9, "id": 161386566875950976 }]
}
```
The code to remove all the record

```python
from pysondb import db
a.db.getDb("test.json")
a.deleteAll()
```

```json
// test.json
{"data": []}
```