### PR TITLE
Added all the left out stuff

### DIFF
--- a/pysondb/cli/cli.py
+++ b/pysondb/cli/cli.py
@@ -138,6 +138,31 @@ def merge(p_file: str, m_file: str, output_file: Optional[str] = None) -> None:
     pass
 
 
+def totwo(primary_file: str, output_file: Optional[str] = None) -> None:
+    """Convert the old schema style DB to the new style"""
+
+    if not Path(primary_file).is_file():
+        print("The file does not exist")
+        quit()
+
+    with open(primary_file, "r") as f:
+        try:
+            new_data: Dict[str, Dict[str, Any]] = {}
+            file_contents = json.load(f)
+            file_data = file_contents["data"]
+
+            for d in file_data:
+                _id = d.pop("id")
+                new_data[_id] = d
+
+            with open(output_file or "converted_data.json", "w") as f:
+                json.dump(new_data, f, indent=4)
+
+        except Exception:
+            print("something went wrong")
+            quit()
+
+
 def main() -> None:
     fire.Fire(
         {
@@ -147,6 +172,7 @@ def main() -> None:
             "convert": convert,
             "converttocsv": convert_db_to_csv,
             "merge": merge,
+            "totwo": totwo
         }
     )
 

--- a/pysondb/imageutils/imageutils.py
+++ b/pysondb/imageutils/imageutils.py
@@ -63,15 +63,16 @@ class setdb:
             raise PathNotFoundError("The src image could not be found")
 
     def get_image(self, name: str) -> None:
-        # if name:
-        #     try:
-        #         img_data = self.db.getBy({"name": name})
-        #         f = open(img_data[0]["fname"], "wb")
-        #         f.write(base64.decodebytes(bytes(img_data[0]["data"], "utf-8")))
-        #         f.close()
-        #     except Exception as e:
-        #         raise SaveError(e)
+        if name:
+            try:
+                img_data = self.db.getBy({"name": name})
+                for img in img_data.values():
+                    f = open(img["fname"], "wb")
+                    f.write(base64.decodebytes(bytes(img["data"], "utf-8")))
+                    f.close()
+            except Exception as e:
+                raise SaveError(e)
 
-        # else:
-        #     raise NoNameError("No name found")
+        else:
+            raise NoNameError("No name found")
         pass

--- a/pysondb/imageutils/imageutils.py
+++ b/pysondb/imageutils/imageutils.py
@@ -75,4 +75,3 @@ class setdb:
 
         else:
             raise NoNameError("No name found")
-        pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ python_requires = >=3
 install_requires =
     fire
     beautifultable
-packages = pysondb
+packages = find:
 zip_safe = False
 
 


### PR DESCRIPTION
a cli command to convert old DB to the new style

Usage:
```commandline
pysondb totwo old.json [new.json]
```
test-old.json
```json
{
	"data": [
		{
			"a": 1,
			"name": "test",
			"id": 224076679045446083
		},
		{
			"a": 2,
			"name": "ad",
			"id": 224076679045446047
		},
		{
			"a": 3,
			"name": "james",
			"id": 224076679045446347
		},
		{
			"a": 4,
			"name": "fred",
			"id": 224076679045446457
		}
	]
}

```

After conversion

test-new.json
```json
{
    "224076679045446083": {
        "a": 1,
        "name": "test"
    },
    "224076679045446047": {
        "a": 2,
        "name": "ad"
    },
    "224076679045446347": {
        "a": 3,
        "name": "james"
    },
    "224076679045446457": {
        "a": 4,
        "name": "fred"
    }
}
```

The imgeutils is fixed

The changes that were made for pysondb1 to 2
 - the `update` method is renamed to `updateBy`
 - the `find` method is removed and the `get` method will do the job of it. The original get method will no longer function properly as the DB is completely represented as dict and it does not have an order.

Other additions
 - Id will no be duplicated
 - look up time using `id` is O(1)
 - you can now use `print` in order to view the db

```python
from pysondb import db
a = db.getDb("test.json")
print(a)  # this will work
```

the only thing left out is the docs