### PR TITLE
Fix .find bug

### DIFF
--- a/pysondb/db.py
+++ b/pysondb/db.py
@@ -112,7 +112,7 @@ class JsonDatabase:
         return self._id_fieldname
 
     def find(self, pk: int):
-        warnings.warn(DeprecationWarning("The find 'method' will be removed. Use 'getByID' instead"), stacklevel=2)
+        warnings.warn(DeprecationWarning("The find 'method' will be removed. Use 'getById' instead"), stacklevel=2)
         return self.getById(pk)
 
     def update(self, db_dataset: Dict[str, Any], new_dataset: Dict[str, Any]):
@@ -215,12 +215,8 @@ class JsonDatabase:
                     db_data = self._get_load_function()(db_file)
                 for d in db_data["data"]:
                     if(d[self.id_fieldname]) == self._cast_id(pk):
-                        return (
-                            d
-
-                        )
-                    else:
-                        raise IdNotFoundError(pk)
+                        return d
+                raise IdNotFoundError(pk)
 
             except:
                 raise IdNotFoundError(pk)

--- a/tests/tests_json_database.py
+++ b/tests/tests_json_database.py
@@ -29,19 +29,6 @@ def test_database_add_many(tmpdir):
     for d in data:
         assert int(d["id"])
 
-def test_database_find(tmpdir):
-    file = tmpdir.join("test.db.json")
-    file.write(EMPTY_FIXTURE_STR)
-    db = Database().on(file.strpath, uuid=False)
-    data = {"name": "test"}
-    xactId = db.add(data)
-    found = db.find(xactId)
-    assert len(found) == len(data)
-    assert set(found.keys())==set(data.keys())
-    for k in data.keys:
-        assert data[k] == found[k]
-    with pytest.raises(IdNotFoundError):
-        db.find(xactId+1)
 
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.json")
@@ -72,6 +59,21 @@ def test_database_get_by(tmpdir):
     assert db.getBy({"getbyfield": "row1"})[0]["name"] == fixture[0]["name"]
     assert db.getBy({"getbyfield": "row2"})[0]["name"] == fixture[1]["name"]
     assert db.getBy({"getbyfield": "row3"})[0]["name"] == fixture[2]["name"]
+
+
+def test_database_get_by_id(tmpdir):
+    file = tmpdir.join("test.db.json")
+    file.write(EMPTY_FIXTURE_STR)
+    db = Database().on(file.strpath, uuid=False)
+    data = {"name": "test"}
+    xactId = db.add(data)
+    found = db.getById(xactId)
+    assert len(found) == len(data)
+    assert set(found.keys()) == set(data.keys())
+    for k in data.keys:
+        assert data[k] == found[k]
+    with pytest.raises(IdNotFoundError):
+        db.getById(xactId+1)
 
 
 def test_database_add_invalid_schema_exception(tmpdir):

--- a/tests/tests_json_database.py
+++ b/tests/tests_json_database.py
@@ -33,11 +33,15 @@ def test_database_find(tmpdir):
     file = tmpdir.join("test.db.json")
     file.write(EMPTY_FIXTURE_STR)
     db = Database().on(file.strpath, uuid=False)
-    xactId = db.add({"name": "test"})
-    data = db.find(xactId)
-    assert len(data) == 1 and list(data.keys())==["name"] and data["name"] == "test"
+    data = {"name": "test"}
+    xactId = db.add(data)
+    found = db.find(xactId)
+    assert len(found) == len(data)
+    assert set(found.keys())==set(data.keys())
+    for k in data.keys:
+        assert data[k] == found[k]
     with pytest.raises(IdNotFoundError):
-        db.find(23)
+        db.find(xactId+1)
 
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.json")

--- a/tests/tests_json_database.py
+++ b/tests/tests_json_database.py
@@ -29,6 +29,15 @@ def test_database_add_many(tmpdir):
     for d in data:
         assert int(d["id"])
 
+def test_database_find(tmpdir):
+    file = tmpdir.join("test.db.json")
+    file.write(EMPTY_FIXTURE_STR)
+    db = Database().on(file.strpath, uuid=False)
+    xactId = db.add({"name": "test"})
+    data = db.find(xactId)
+    assert len(data) == 1 and list(data.keys())==["name"] and data["name"] == "test"
+    with pytest.raises(IdNotFoundError):
+        db.find(23)
 
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.json")

--- a/tests/tests_json_uuid_database.py
+++ b/tests/tests_json_uuid_database.py
@@ -32,21 +32,6 @@ def test_database_add_many(tmpdir):
         assert uuid.UUID(d["id"])
 
 
-def test_database_find(tmpdir):
-    file = tmpdir.join("test.db.json")
-    file.write(EMPTY_FIXTURE_STR)
-    db = Database().on(file.strpath)
-    data = {"name": "test"}
-    xactId = db.add(data)
-    found = db.find(xactId)
-    assert len(found) == len(data)
-    assert set(found.keys())==set(data.keys())
-    for k in data.keys:
-        assert data[k] == found[k]
-    with pytest.raises(IdNotFoundError):
-        db.find(xactId+1)
-
-
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.json")
     file.write(EMPTY_FIXTURE_STR)
@@ -76,6 +61,21 @@ def test_database_get_by(tmpdir):
     assert db.getBy({"getbyfield": "row1"})[0]["name"] == fixture[0]["name"]
     assert db.getBy({"getbyfield": "row2"})[0]["name"] == fixture[1]["name"]
     assert db.getBy({"getbyfield": "row3"})[0]["name"] == fixture[2]["name"]
+
+
+def test_database_get_by_id(tmpdir):
+    file = tmpdir.join("test.db.json")
+    file.write(EMPTY_FIXTURE_STR)
+    db = Database().on(file.strpath)
+    data = {"name": "test"}
+    xactId = db.add(data)
+    found = db.getById(xactId)
+    assert len(found) == len(data)
+    assert set(found.keys()) == set(data.keys())
+    for k in data.keys:
+        assert data[k] == found[k]
+    with pytest.raises(IdNotFoundError):
+        db.getById(xactId+1)
 
 
 def test_database_add_invalid_schema_exception(tmpdir):

--- a/tests/tests_json_uuid_database.py
+++ b/tests/tests_json_uuid_database.py
@@ -120,7 +120,7 @@ def test_database_delete_by_id(tmpdir):
     file.write(UUID_FIXTURE_STR)
     db = Database().on(file.strpath)
     assert db.deleteById(UUID_FIXTURE["data"][0]["id"])
-    assert not len(db.get())
+    assert not bool(len(db.get()))
     fixture = [
         {"name": "test", "getbyfield": "row1"},
         {"name": "test works!", "getbyfield": "row2"},
@@ -133,6 +133,6 @@ def test_database_delete_by_id(tmpdir):
     assert db.deleteById(db.get()[0]["id"])
     assert len(db.getAll()) == 1
     assert db.deleteById(db.get()[0]["id"])
-    assert not len(db.get())
+    assert not bool(len(db.get()))
     with pytest.raises(IdNotFoundError):
         assert db.deleteById(20)

--- a/tests/tests_json_uuid_database.py
+++ b/tests/tests_json_uuid_database.py
@@ -32,6 +32,21 @@ def test_database_add_many(tmpdir):
         assert uuid.UUID(d["id"])
 
 
+def test_database_find(tmpdir):
+    file = tmpdir.join("test.db.json")
+    file.write(EMPTY_FIXTURE_STR)
+    db = Database().on(file.strpath)
+    data = {"name": "test"}
+    xactId = db.add(data)
+    found = db.find(xactId)
+    assert len(found) == len(data)
+    assert set(found.keys())==set(data.keys())
+    for k in data.keys:
+        assert data[k] == found[k]
+    with pytest.raises(IdNotFoundError):
+        db.find(xactId+1)
+
+
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.json")
     file.write(EMPTY_FIXTURE_STR)

--- a/tests/tests_yaml_database.py
+++ b/tests/tests_yaml_database.py
@@ -31,6 +31,21 @@ def test_database_add_many(tmpdir):
         assert int(d["id"])
 
 
+def test_database_find(tmpdir):
+    file = tmpdir.join("test.db.yaml")
+    file.write(EMPTY_FIXTURE_STR)
+    db = Database().on(file.strpath, uuid=False)
+    data = {"name": "test"}
+    xactId = db.add(data)
+    found = db.find(xactId)
+    assert len(found) == len(data)
+    assert set(found.keys())==set(data.keys())
+    for k in data.keys:
+        assert data[k] == found[k]
+    with pytest.raises(IdNotFoundError):
+        db.find(xactId+1)
+
+
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.yaml")
     file.write(EMPTY_FIXTURE_STR)

--- a/tests/tests_yaml_database.py
+++ b/tests/tests_yaml_database.py
@@ -31,21 +31,6 @@ def test_database_add_many(tmpdir):
         assert int(d["id"])
 
 
-def test_database_find(tmpdir):
-    file = tmpdir.join("test.db.yaml")
-    file.write(EMPTY_FIXTURE_STR)
-    db = Database().on(file.strpath, uuid=False)
-    data = {"name": "test"}
-    xactId = db.add(data)
-    found = db.find(xactId)
-    assert len(found) == len(data)
-    assert set(found.keys())==set(data.keys())
-    for k in data.keys:
-        assert data[k] == found[k]
-    with pytest.raises(IdNotFoundError):
-        db.find(xactId+1)
-
-
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.yaml")
     file.write(EMPTY_FIXTURE_STR)
@@ -75,6 +60,21 @@ def test_database_get_by(tmpdir):
     assert db.getBy({"getbyfield": "row1"})[0]["name"] == fixture[0]["name"]
     assert db.getBy({"getbyfield": "row2"})[0]["name"] == fixture[1]["name"]
     assert db.getBy({"getbyfield": "row3"})[0]["name"] == fixture[2]["name"]
+
+
+def test_database_get_by_id(tmpdir):
+    file = tmpdir.join("test.db.yaml")
+    file.write(EMPTY_FIXTURE_STR)
+    db = Database().on(file.strpath, uuid=False)
+    data = {"name": "test"}
+    xactId = db.add(data)
+    found = db.getById(xactId)
+    assert len(found) == len(data)
+    assert set(found.keys()) == set(data.keys())
+    for k in data.keys:
+        assert data[k] == found[k]
+    with pytest.raises(IdNotFoundError):
+        db.getById(xactId+1)
 
 
 def test_database_add_invalid_schema_exception(tmpdir):

--- a/tests/tests_yaml_uuid_database.py
+++ b/tests/tests_yaml_uuid_database.py
@@ -33,6 +33,21 @@ def test_database_add_many(tmpdir):
         assert uuid.UUID(d["id"])
 
 
+def test_database_find(tmpdir):
+    file = tmpdir.join("test.db.yaml")
+    file.write(EMPTY_FIXTURE_STR)
+    db = Database().on(file.strpath)
+    data = {"name": "test"}
+    xactId = db.add(data)
+    found = db.find(xactId)
+    assert len(found) == len(data)
+    assert set(found.keys())==set(data.keys())
+    for k in data.keys:
+        assert data[k] == found[k]
+    with pytest.raises(IdNotFoundError):
+        db.find(xactId+1)
+
+
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.yaml")
     file.write(EMPTY_FIXTURE_STR)

--- a/tests/tests_yaml_uuid_database.py
+++ b/tests/tests_yaml_uuid_database.py
@@ -33,21 +33,6 @@ def test_database_add_many(tmpdir):
         assert uuid.UUID(d["id"])
 
 
-def test_database_find(tmpdir):
-    file = tmpdir.join("test.db.yaml")
-    file.write(EMPTY_FIXTURE_STR)
-    db = Database().on(file.strpath)
-    data = {"name": "test"}
-    xactId = db.add(data)
-    found = db.find(xactId)
-    assert len(found) == len(data)
-    assert set(found.keys())==set(data.keys())
-    for k in data.keys:
-        assert data[k] == found[k]
-    with pytest.raises(IdNotFoundError):
-        db.find(xactId+1)
-
-
 def test_database_get(tmpdir):
     file = tmpdir.join("test.db.yaml")
     file.write(EMPTY_FIXTURE_STR)
@@ -77,6 +62,21 @@ def test_database_get_by(tmpdir):
     assert db.getBy({"getbyfield": "row1"})[0]["name"] == fixture[0]["name"]
     assert db.getBy({"getbyfield": "row2"})[0]["name"] == fixture[1]["name"]
     assert db.getBy({"getbyfield": "row3"})[0]["name"] == fixture[2]["name"]
+
+
+def test_database_get_by_id(tmpdir):
+    file = tmpdir.join("test.db.yaml")
+    file.write(EMPTY_FIXTURE_STR)
+    db = Database().on(file.strpath)
+    data = {"name": "test"}
+    xactId = db.add(data)
+    found = db.getById(xactId)
+    assert len(found) == len(data)
+    assert set(found.keys()) == set(data.keys())
+    for k in data.keys:
+        assert data[k] == found[k]
+    with pytest.raises(IdNotFoundError):
+        db.getById(xactId+1)
 
 
 def test_database_add_invalid_schema_exception(tmpdir):


### PR DESCRIPTION
Fixed the bug with .getById function (#34). Also updated the deprecation warning in .find and added tests for .find function.
Would it be better to have the tests call getById instead?