### PR TITLE
doc: fix typo in get.md

### DIFF
--- a/docs/get.md
+++ b/docs/get.md
@@ -22,7 +22,7 @@
 
 * returns only one data by default.
 
-* get(3) => retruns 3 json data. 
+* get(3) => returns 3 json data. 
 
 path.json
 


### PR DESCRIPTION
fix typo error retruns -> returns
